### PR TITLE
Add els:distinct-values function in els-common_strings.xsl file

### DIFF
--- a/src/main/xsl/els-common_strings.xsl
+++ b/src/main/xsl/els-common_strings.xsl
@@ -97,6 +97,22 @@
 
   <xd:doc>
     <xd:desc>
+      <xd:p>Returns first distincts values from strings sequence by keeping order.</xd:p>
+    </xd:desc>
+    <xd:param name="strs">[xs:string*] ordered list of duplicated strings.</xd:param>
+    <xd:return>[xs:string*] ordered list of unique strings keeping order.</xd:return>
+  </xd:doc>
+  <xsl:function name="els:distinct-values" as="xs:string*">
+    <xsl:param name="strs" as="xs:string*"/>
+    <xsl:sequence select="fold-left(
+      $strs,
+      (),
+      function($a, $b) { if (not($a = $b)) then (($a,$b)) else ($a) }
+      )"/>
+  </xsl:function>
+
+  <xd:doc>
+    <xd:desc>
       <xd:p>Normalize the string: remove diacritic marks.</xd:p>
       <xd:p>Example: els:normalize-no-diacritic('éêèàœç')='eeeaœc'</xd:p>
     </xd:desc>

--- a/src/test/xspec/els-common_strings.xspec
+++ b/src/test/xspec/els-common_strings.xspec
@@ -70,6 +70,12 @@
     <x:expect label="String with replacements" select="'MAC 2018#SEP#2016#SEP#2015#SEP#2018'"/>
   </x:scenario>
   
+  <x:scenario label="els:distinct-values">
+    <x:call function="els:distinct-values">
+      <x:param name="strs" select="('a', 'b', 'c', 'a', 'd', 'b')"/>
+    </x:call>
+    <x:expect label="('a', 'b', 'c', 'd')" select="('a', 'b', 'c', 'd')"/>
+  </x:scenario>
 
   <x:scenario label="els:normalize-no-diacritic">
     <x:call function="els:normalize-no-diacritic">


### PR DESCRIPTION
Hello Matthieu,

*** FRANCAIS ***
J'ai créé la branche "ADD_els_distinct-values_FCT" depuis la branche "master".
Cette nouvelle branche contient à présent la fonction "els:distinct-values" qui permet d'obtenir, à partir d'une séquence de string, un nouvelle séquence qui ne contient que les premiers éléments distincts. L'ordre de ces éléments est gardé.
Merci de valider cet ajout, buddy :)

*** ENGLISH ***
I created the "ADD_els_distinct-values_FCT" branch from the "master" branch.
This new branch now contains the "els: distinct-values" function which makes it possible to obtain, from a string sequence, a new sequence that contains only the first distinct elements. The order of these elements is kept.
Thank you for confirming this add, buddy :)

Fred